### PR TITLE
[FEATURE] Refactor configuration handling and EEPROM integration

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -75,6 +75,14 @@ Die folgenden Bibliotheken werden verwendet und sind in der `platformio.ini` Dat
 
 ## Change Log
 
+### [0.3.0]
+
+#### Breaking Changes
+
+- Die Einstellung zum Verbinden mit dem Server wurde von `Config.h` entfernt. Nun muss beim erste initialiserung des ESP32 folgende Zeichenkette in Serial Monitor eingegeben werden:
+  - `apn="";gprsUser="";gprsPass="";GSM_PIN="";server="";port=;username="";password="";`
+
+
 ### [0.2.0]
 
 #### Hinzugefügt

--- a/include/Config_template.h
+++ b/include/Config_template.h
@@ -5,22 +5,20 @@
 
 #define UART_BAUD 115200
 
-#define TINY_GSM_MODEM_SIM7000SSL
+#define TINY_GSM_MODEM_SIM7000
 #define TINY_GSM_RX_BUFFER 1024 // 1Kb
 
-// LED Pin
-#define LED_PIN 12
-// Anzahl die LEDs
+#define LED_PIN 21
 #define LED_COUNT 3
-
-// Schlüssel knopfe
-#define OPEN_KEY 15
-#define CLOSE_KEY 14
 
 // Modem Pins
 #define PIN_TX 27
 #define PIN_RX 26
 #define PWR_PIN 4
+
+// Schlüssel knopfe
+#define OPEN_KEY 15
+#define CLOSE_KEY 14
 
 /*
  *   2 Automatic
@@ -37,25 +35,11 @@ extern byte NETWORK_MODE;
  */
 extern byte PREFERRED_MODE;
 
-// GPRS und apn Daten
-const char apn[] = ""; // Zb: iot.1nce.net
-const char gprsUser[] = "";
-const char gprsPass[] = "";
-
-// Sim pin
-#define GSM_PIN ""
-
 // NFC Modul Pins
 #define NFC_MOSI 23
 #define NFC_MISO 19
 #define NFC_SCLK 18
 #define NFC_SS 5
-
-// Server Daten für abholen der RFID's usw.
-const char server[] = "";
-const int port = 443;
-const char username[] = "";
-const char password[] = "";
 
 // ESP32 startet sich jeden tag um die Uhrzeit neu
 const unsigned long targetTimeToRestartESP32 = (19 * 3600 + 30 * 60) * 1000; // 19:30 Uhr

--- a/include/HelperUtils.h
+++ b/include/HelperUtils.h
@@ -6,12 +6,18 @@
 #include <Config.h>
 #include <Intern.h>
 #include <WiFi.h>
+#include <EEPROM.h>
 
 class HelperUtils
 {
 public:
     static String getMacAddress();
     static String toUpperCase(const String &str);
+    static void initEEPROM(Config &config);
+    static void saveConfigToEEPROM(Config &config);
+    static bool loadConfigFromEEPROM(Config &config);
+    static void parseConfigString(String &inputString, Config &config);
+    static void resetEEPROM();
 };
 
 #endif

--- a/include/Intern.h
+++ b/include/Intern.h
@@ -9,4 +9,24 @@
 
 extern String MAC_ADDRESS;
 
+#define CONFIG_START_ADDRESS 0
+#define CONFIG_VERSION 1
+
+// FIXME: Port aus config lesen hat beim http(client, config.server, config.port) nicht funktioniert...
+// Ersmal als globale Variable speichern.
+const int port = 8080; 
+
+struct Config
+{
+  uint8_t version; // Wird verwendet, um eine Versionsnummer oder Signatur zu speichern
+  char apn[32];
+  char gprsUser[32];
+  char gprsPass[32];
+  char GSM_PIN[16];
+  char server[64];
+  int port;
+  char username[32];
+  char password[64];
+};
+
 #endif

--- a/src/HelperUtils.cpp
+++ b/src/HelperUtils.cpp
@@ -31,3 +31,79 @@ String HelperUtils::getMacAddress()
     }
     return HelperUtils::toUpperCase(macStr);
 }
+
+void HelperUtils::initEEPROM(Config &config)
+{
+    EEPROM.begin(sizeof(Config));
+}
+
+void HelperUtils::saveConfigToEEPROM(Config &config)
+{
+    config.version = CONFIG_VERSION;
+    EEPROM.put(CONFIG_START_ADDRESS, config);
+    EEPROM.commit();
+    Serial.println("Konfiguration wurde gespeichert.");
+}
+
+bool HelperUtils::loadConfigFromEEPROM(Config &config)
+{
+    EEPROM.get(CONFIG_START_ADDRESS, config);
+    if (config.version != CONFIG_VERSION)
+    {
+        return false; 
+    }
+    return true;
+}
+
+void HelperUtils::parseConfigString(String &inputString, Config &config) {
+  // String anhand von ';' aufteilen
+  int start = 0;
+  while (start < inputString.length()) {
+    int end = inputString.indexOf(';', start);
+    if (end == -1) {
+      end = inputString.length();
+    }
+    String token = inputString.substring(start, end);
+    // Token verarbeiten, sollte in der Form key="value" oder key=value sein
+    int eqIndex = token.indexOf('=');
+    if (eqIndex != -1) {
+      String key = token.substring(0, eqIndex);
+      String value = token.substring(eqIndex + 1);
+      value.trim();
+      if (value.startsWith("\"") && value.endsWith("\"")) {
+        value = value.substring(1, value.length() - 1);
+      }
+      key.trim();
+      if (key == "apn") {
+        value.toCharArray(config.apn, sizeof(config.apn));
+      } else if (key == "gprsUser") {
+        value.toCharArray(config.gprsUser, sizeof(config.gprsUser));
+      } else if (key == "gprsPass") {
+        value.toCharArray(config.gprsPass, sizeof(config.gprsPass));
+      } else if (key == "GSM_PIN") {
+        value.toCharArray(config.GSM_PIN, sizeof(config.GSM_PIN));
+      } else if (key == "server") {
+        value.toCharArray(config.server, sizeof(config.server));
+      } else if (key == "port") {
+        config.port = value.toInt();
+      } else if (key == "username") {
+        value.toCharArray(config.username, sizeof(config.username));
+      } else if (key == "password") {
+        value.toCharArray(config.password, sizeof(config.password));
+      } else {
+        Serial.print("Unbekannter Schlüssel: ");
+        Serial.println(key);
+      }
+    }
+    start = end + 1;
+  }
+}
+
+// Funktion zum Zurücksetzen des EEPROM
+void HelperUtils::resetEEPROM() {
+  Config emptyConfig;
+  emptyConfig.version = 0xFF; 
+  EEPROM.put(CONFIG_START_ADDRESS, emptyConfig);
+  EEPROM.commit();
+  Serial.println("EEPROM wurde zurückgesetzt.");
+}


### PR DESCRIPTION
### **BREAKING CHANGE**

Die Einstellungen `apn`, `gprsUser`, `gprsPass`, `GSM_PIN`, `server`, `port`, `username` und `password` werden aus Sicherheitsgründen nicht mehr in der `Config.h`-Datei gespeichert. Stattdessen müssen sie bei der ersten Initialisierung des ESP32 im Serial Monitor in folgendem Format eingegeben werden:
`apn="";gprsUser="";gprsPass="";GSM_PIN="";server="";port=;username="";password="";`