### PR TITLE
Hardware Watchdog

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -78,6 +78,15 @@ Die folgenden Bibliotheken werden verwendet und sind in der `platformio.ini` Dat
 
 ## Change Log
 
+### [0.5.0]
+
+#### Verändert
+
+- Ein Hardware-Watchdog wurde aktiviert, um den Arduino bei unerwartetem Verhalten automatisch neu zu starten.
+    - Der Arduino setzt den Watchdog regelmäßig alle `HW_WATCHDOG_RESET_DELAY_MS` = 100ms zurück. Der tatsächliche Timeout
+      liegt bei `HW_WATCHDOG_TIMEOUT` = 300s (5min) – wird der Watchdog innerhalb dieser Zeit nicht zurückgesetzt,
+      erfolgt ein automatischer Reset.
+
 ### [0.4.3]
 
 #### Verändert

--- a/include/Config_template.h
+++ b/include/Config_template.h
@@ -51,4 +51,7 @@ extern byte PREFERRED_MODE;
 // ESP32 startet sich jeden tag um die Uhrzeit neu
 const unsigned long targetTimeToRestartESP32 = (19 * 3600 + 30 * 60) * 1000; // 19:30 Uhr
 
+#define HW_WATCHDOG_TIMEOUT (300) // [Sekunden] Maximal erlaubte Zeit ohne Reset – nach 5 Minuten startet der HW-Watchdog den Arduino neu
+#define HW_WATCHDOG_RESET_DELAY_MS (100) // [Millisekunden] Der Arduino muss spätestens alle 100ms den Watchdog zurücksetzen, damit der 5-Minuten-Timeout nicht abläuft
+
 #endif

--- a/include/HelperUtils.h
+++ b/include/HelperUtils.h
@@ -18,6 +18,7 @@ public:
     static bool loadConfigFromEEPROM(Config &config);
     static void parseConfigString(String &inputString, Config &config);
     static void resetEEPROM();
+    static String getResetReasonHumanReadable(esp_reset_reason_t reset_reason);
 };
 
 #endif

--- a/include/Intern.h
+++ b/include/Intern.h
@@ -2,7 +2,7 @@
 #ifndef Intern_H
 #define Intern_H
 
-#define FIRMWARE_VERSION "0.4.3"
+#define FIRMWARE_VERSION "0.5.0"
 #define RFID_FILE_NAME "/rfids.txt"
 #define FIRMWARE_FILE_NAME "/firmware.bin"
 #define LOG_FILE_NAME "/logs.json"

--- a/src/HelperUtils.cpp
+++ b/src/HelperUtils.cpp
@@ -107,3 +107,32 @@ void HelperUtils::resetEEPROM() {
   EEPROM.commit();
   Serial.println("EEPROM wurde zurückgesetzt.");
 }
+
+String HelperUtils::getResetReasonHumanReadable(const esp_reset_reason_t reset_reason) {
+    switch (reset_reason) {
+        case ESP_RST_POWERON:
+            return "Reset due to power-on event";
+        case ESP_RST_BROWNOUT:
+            return "Brownout reset";
+        case ESP_RST_SDIO:
+            return "Reset over SDIO";
+        case ESP_RST_PANIC:
+            return "Software reset due to exception/panic";
+        case ESP_RST_INT_WDT:
+            return "Reset due to interrupt watchdog";
+        case ESP_RST_TASK_WDT:
+            return "Reset due to task watchdog";
+        case ESP_RST_WDT:
+            return "General watchdog reset";
+        case ESP_RST_DEEPSLEEP:
+            return "Reset after exiting deep sleep mode";
+        case ESP_RST_EXT:
+            return "Reset by external pin";
+        case ESP_RST_UNKNOWN:
+            return "Reset reason could not be determined";
+        case ESP_RST_SW:
+            return "Software reset via esp_restart";
+        default:
+            return "Unknown reset reason";
+    }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include <SPIFFSUtils.h>
 #include <HelperUtils.h>
 #include <LED.h>
+#include <esp_system.h>
 
 bool loggedIn = false;
 unsigned long targetMillis;
@@ -96,6 +97,11 @@ void setup()
     while (!Serial)
     {
     };
+
+    const esp_reset_reason_t reset_reason = esp_reset_reason();
+
+    Serial.print("ESP32 startup. Reset Reason: ");
+    Serial.println(HelperUtils::getResetReasonHumanReadable(reset_reason));
 
     HelperUtils::initEEPROM(config);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,9 +4,15 @@
 #include <SPIFFSUtils.h>
 #include <HelperUtils.h>
 #include <LED.h>
+#include <esp32-hal.h>
 #include <esp_system.h>
+#include <esp_task_wdt.h>
+
+#define HW_WATCHDOG_TIMEOUT (300) // [Seconds], 5mins
+#define HW_WATCHDOG_RESET_DELAY_MS (100) // [Milliseconds]
 
 bool loggedIn = false;
+unsigned long nextWatchdogResetMs;
 unsigned long targetMillis;
 const unsigned long dayMillis = 24 * 60 * 60 * 1000; // Ein Tag in Millisekunden
 String MAC_ADDRESS;
@@ -91,6 +97,51 @@ void initTime()
     targetMillis += millis(); // Setze Zielzeit relativ zu millis()
 }
 
+void initWatchdog() {
+    // Set hw watchdog timeout. The watchdog will reset the device after this timeout
+
+    Serial.print("Initializing the Task Watchdog Timer... ");
+    const esp_err_t watchdog_init_err = esp_task_wdt_init(HW_WATCHDOG_TIMEOUT, true);
+
+    switch (watchdog_init_err) {
+        case ESP_OK:
+            Serial.println("Success");
+            break;
+        case ESP_ERR_NO_MEM:
+            Serial.println("Failed due to lack of memory!");
+            break;
+        default:
+            Serial.println("Unknown status!");
+            break;
+    }
+
+    // Add the current task (main loop) to be monitored by the watchdog.
+    // This ensures that if the main loop doesn't reset the watchdog in time,
+    // the ESP32 will reset itself.
+
+    Serial.print("Subscribing the current task to the Task Watchdog Timer... ");
+
+    const esp_err_t error_code = esp_task_wdt_add(nullptr);
+
+    switch (error_code) {
+        case ESP_OK:
+            Serial.println("Success");
+            break;
+        case ESP_ERR_INVALID_ARG:
+            Serial.println("Error, the task is already subscribed!");
+            break;
+        case ESP_ERR_NO_MEM:
+            Serial.println("Error, could not subscribe the task due to lack of memory!");
+            break;
+        case ESP_ERR_INVALID_STATE:
+            Serial.println("Error, the Task Watchdog Timer has not been initialized yet!");
+            break;
+        default:
+            Serial.println("Unknown status!");
+            break;
+    }
+}
+
 void setup()
 {
     Serial.begin(UART_BAUD);
@@ -102,6 +153,11 @@ void setup()
 
     Serial.print("ESP32 startup. Reset Reason: ");
     Serial.println(HelperUtils::getResetReasonHumanReadable(reset_reason));
+
+    // Initialize the watchdog.
+    // WARNING: If this setup function does not complete within the given HW_WATCHDOG_TIMEOUT the watchdog will perform a reset.
+    // That could possibly lead to an infinite resetting loop.
+    initWatchdog();
 
     HelperUtils::initEEPROM(config);
 
@@ -166,10 +222,13 @@ void setup()
     LED_Strip.clear();
 }
 
-void loop()
-{
-    if (millis() >= targetMillis)
-    {
+void loop() {
+    if (millis() >= nextWatchdogResetMs) {
+        esp_task_wdt_reset(); // Reset the watchdog timer
+        nextWatchdogResetMs = millis() + HW_WATCHDOG_RESET_DELAY_MS;
+    }
+
+    if (millis() >= targetMillis) {
         Serial.println("Target time reached.");
         Serial.println("Uploading logs and restarting ESP32...");
         SPIFFSUtils::addLogEntry("ESP32 wird neu gestartet");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,9 +8,6 @@
 #include <esp_system.h>
 #include <esp_task_wdt.h>
 
-#define HW_WATCHDOG_TIMEOUT (300) // [Seconds], 5mins
-#define HW_WATCHDOG_RESET_DELAY_MS (100) // [Milliseconds]
-
 bool loggedIn = false;
 unsigned long nextWatchdogResetMs;
 unsigned long targetMillis;


### PR DESCRIPTION
Issue: #22

- Print the reset reason over serial.
- Initialize the hardware watchdog at the start of the `setup` function, after `Serial.begin`.

> [!WARNING]  
> The watchdog resets the device after 5 minutes. If the `setup` function does not complete within that time frame, the watchdog will trigger a reset, which could potentially lead to an infinite reset loop.
> Of course, the 5-minute timeout can be increased, or the watchdog initialization can occur at the end of the `setup` function, after tasks that take longer to complete.

The watchdog is fed every 100 milliseconds in the `loop` function.

> [!CAUTION]  
> The changes have not been properly tested. Please test the code and verify it on your devices!

It does **not** yet log how often the device has been reset. I am unsure of how to implement this and whether overflowing logs should be of concern.