### PR TITLE
Watchdog für ota download

### DIFF
--- a/include/Config_template.h
+++ b/include/Config_template.h
@@ -51,7 +51,8 @@ extern byte PREFERRED_MODE;
 // ESP32 startet sich jeden tag um die Uhrzeit neu
 const unsigned long targetTimeToRestartESP32 = (03 * 3600 + 30 * 60) * 1000; // 03:30 Uhr
 
-#define HW_WATCHDOG_TIMEOUT (300) // [Sekunden] Maximal erlaubte Zeit ohne Reset – nach 5 Minuten startet der HW-Watchdog den Arduino neu
+#define HW_WATCHDOG_DEFAULT_TIMEOUT (300) // [Sekunden] Maximal erlaubte Zeit ohne Reset – nach 5 Minuten startet der HW-Watchdog den Arduino neu
+#define HW_WATCHDOG_OTA_UPDATE_TIMEOUT (3600) // [Sekunden] Maximal erlaubte Zeit ohne Reset während eines OTA Updates
 #define HW_WATCHDOG_RESET_DELAY_MS (100) // [Millisekunden] Der Arduino muss spätestens alle 100ms den Watchdog zurücksetzen, damit der 5-Minuten-Timeout nicht abläuft
 
 #endif

--- a/include/HelperUtils.h
+++ b/include/HelperUtils.h
@@ -19,6 +19,8 @@ public:
     static void parseConfigString(String &inputString, Config &config);
     static void resetEEPROM();
     static String getResetReasonHumanReadable(esp_reset_reason_t reset_reason);
+    static esp_err_t setWatchdog(uint32_t watchdog_timeout);
+    static esp_err_t subscribeTaskToWatchdog();
 };
 
 #endif

--- a/include/Modem.h
+++ b/include/Modem.h
@@ -20,6 +20,7 @@ public:
     int sendRequest(String path, String method, String body = "");
     String *getRfids(int &arraySize);
     void firmwareCheckAndUpdateIfNeeded();
+    void handleFirmwareUpdateWithWatchdog();
     bool uploadLogs();
 
 private:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,51 +94,6 @@ void initTime()
     targetMillis += millis(); // Setze Zielzeit relativ zu millis()
 }
 
-void initWatchdog() {
-    // Set hw watchdog timeout. The watchdog will reset the device after this timeout
-
-    Serial.print("Initializing the Task Watchdog Timer... ");
-    const esp_err_t watchdog_init_err = esp_task_wdt_init(HW_WATCHDOG_TIMEOUT, true);
-
-    switch (watchdog_init_err) {
-        case ESP_OK:
-            Serial.println("Success");
-            break;
-        case ESP_ERR_NO_MEM:
-            Serial.println("Failed due to lack of memory!");
-            break;
-        default:
-            Serial.println("Unknown status!");
-            break;
-    }
-
-    // Add the current task (main loop) to be monitored by the watchdog.
-    // This ensures that if the main loop doesn't reset the watchdog in time,
-    // the ESP32 will reset itself.
-
-    Serial.print("Subscribing the current task to the Task Watchdog Timer... ");
-
-    const esp_err_t error_code = esp_task_wdt_add(nullptr);
-
-    switch (error_code) {
-        case ESP_OK:
-            Serial.println("Success");
-            break;
-        case ESP_ERR_INVALID_ARG:
-            Serial.println("Error, the task is already subscribed!");
-            break;
-        case ESP_ERR_NO_MEM:
-            Serial.println("Error, could not subscribe the task due to lack of memory!");
-            break;
-        case ESP_ERR_INVALID_STATE:
-            Serial.println("Error, the Task Watchdog Timer has not been initialized yet!");
-            break;
-        default:
-            Serial.println("Unknown status!");
-            break;
-    }
-}
-
 void setup()
 {
     Serial.begin(UART_BAUD);
@@ -154,7 +109,11 @@ void setup()
     // Initialize the watchdog.
     // WARNING: If this setup function does not complete within the given HW_WATCHDOG_TIMEOUT the watchdog will perform a reset.
     // That could possibly lead to an infinite resetting loop.
-    initWatchdog();
+    HelperUtils::setWatchdog(HW_WATCHDOG_DEFAULT_TIMEOUT);
+    // Add the current task to be monitored by the watchdog.
+    // This ensures that if the main loop doesn't reset the watchdog in time,
+    // the ESP32 will reset itself.
+    HelperUtils::subscribeTaskToWatchdog();
 
     HelperUtils::initEEPROM(config);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,7 +155,7 @@ void setup()
     SPIFFSUtils::addLogEntry("ESP32 wird initialisiert");
 
     LED_Strip.setStaticColor("purple");
-    modem.firmwareCheckAndUpdateIfNeeded();
+    modem.handleFirmwareUpdateWithWatchdog();
 
     LED_Strip.setStaticColor("orange");
 


### PR DESCRIPTION
Schließt #23.
Setzt den Watchdog timeout auf 1 Stunde vor einem OTA Update. Danach wird er wieder auf 5min gesetzt.

> [!WARNING]
> Alles ungetestet. Bitte vorher testen!